### PR TITLE
Update version to 0.1.2 and streamline OpenAI health check for GPT-5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ai-healthcheck"
-version = "0.1.1"
+version = "0.1.2"
 description = "Lightweight health checks for OpenAI"
 authors = ["Minseok Song <minseok.song@mssong.com>"]
 repository = "https://github.com/skytin1004/ai-healthcheck"

--- a/src/ai_healthcheck/openai.py
+++ b/src/ai_healthcheck/openai.py
@@ -49,9 +49,7 @@ def check_openai(
         "messages": [
             {"role": "system", "content": "health check"},
             {"role": "user", "content": "ping"},
-        ],
-        "max_tokens": 1,
-        "temperature": 0,
+        ]
     }
 
     try:


### PR DESCRIPTION
# chore: Update version to 0.1.2 and streamline OpenAI health check for GPT-5

## Purpose

Modernize the OpenAI health check request structure to align with GPT-5 expectations and publish a corresponding version bump.

## Description

This PR updates the package version from **0.1.1 → 0.1.2** and removes two parameters (`max_tokens`, `temperature`) from the health-check payload in `openai.py`.

These fields are unnecessary for a minimal “ping” request and may cause warnings or incompatibilities with GPT-5. The request body is now simplified to the essential `messages` field.

## Related Issue

<!-- Add reference if applicable -->

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

The behavior of the health check remains unchanged aside from the streamlined payload.

## Type of change

- [ ] Bugfix  
- [x] Feature  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other

## Checklist

- [x] I have thoroughly tested my changes  
- [x] All existing tests pass  
- [ ] I have added new tests (if applicable)  
- [x] I have followed the Co-op Translators coding conventions  
- [ ] I have documented my changes (if applicable)

## Additional context

The change aligns this library with GPT-5's simplified chat completion schema, reducing unnecessary parameters for a simple health check.
